### PR TITLE
Fix colorful noise on model textures

### DIFF
--- a/src/stage.go
+++ b/src/stage.go
@@ -2544,7 +2544,7 @@ func loadEnvironment(filepath string) (*Environment, error) {
 				return
 			}
 			lowestMipLevel := int32(4)
-			env.hdrTexture.tex = gfx.newHDRTexture(int32(img.Bounds().Max.X), int32(img.Bounds().Max.Y))
+			env.hdrTexture.tex = gfx.newHDRTexture(int32(img.Bounds().Dx()), int32(img.Bounds().Dy()))
 
 			env.hdrTexture.tex.SetPixelData(data)
 			env.cubeMapTexture.tex = gfx.newCubeMapTexture(256, true, 0)
@@ -2705,7 +2705,7 @@ func loadglTFModel(filepath string) (*Model, error) {
 				rgba := image.NewRGBA(img.Bounds())
 				draw.Draw(rgba, img.Bounds(), img, img.Bounds().Min, draw.Src)
 				sys.mainThreadTask <- func() {
-					texture.tex = gfx.newModelTexture(int32(img.Bounds().Max.X), int32(img.Bounds().Max.Y), 32, false)
+					texture.tex = gfx.newModelTexture(int32(img.Bounds().Dx()), int32(img.Bounds().Dy()), 32, false)
 					texture.tex.SetDataG(rgba.Pix, mag, min, wrapS, wrapT)
 				}
 				textureMap[[2]int32{int32(*t.Source), int32(*t.Sampler)}] = texture
@@ -2724,7 +2724,7 @@ func loadglTFModel(filepath string) (*Model, error) {
 				rgba := image.NewRGBA(img.Bounds())
 				draw.Draw(rgba, img.Bounds(), img, img.Bounds().Min, draw.Src)
 				sys.mainThreadTask <- func() {
-					texture.tex = gfx.newModelTexture(int32(img.Bounds().Max.X), int32(img.Bounds().Max.Y), 32, false)
+					texture.tex = gfx.newModelTexture(int32(img.Bounds().Dx()), int32(img.Bounds().Dy()), 32, false)
 					texture.tex.SetDataG(rgba.Pix, mag, min, wrapS, wrapT)
 				}
 				textureMap[[2]int32{int32(*t.Source), -1}] = texture


### PR DESCRIPTION
The "colorful noise" bug on model textures (especially on GLES32) was caused by incorrect texture dimension calculations in `src/stage.go`. 

When loading textures from `glTF` models or HDR environments, the code was using `img.Bounds().Max.X` and `img.Bounds().Max.Y` as the width and height. However, Go's `image.Image` bounds can have a non-zero origin (Min point). `image.NewRGBA(img.Bounds())` preserves this origin. If `Min` is not `(0,0)`, `Max` values are larger than the actual width/height (`Dx`/`Dy`). 

This caused the renderer to allocate a texture buffer larger than the pixel data provided, leading `glTexImage2D` to read past the end of the pixel buffer into uninitialized memory (garbage), resulting in visual noise.

This fix replaces `Max.X/Y` with `Dx()/Dy()` in `loadglTFModel` and `loadEnvironment`, ensuring the texture dimensions match the pixel buffer size.


---
*PR created automatically by Jules for task [17636535488623541982](https://jules.google.com/task/17636535488623541982) started by @potsmugen*